### PR TITLE
Fix broken GitHub features Watch and Star links by updating repo reference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,5 +2,5 @@ remote_theme: "owasp/www--site-theme@main"
 plugins:
  - jekyll-include-cache-0.2.0
 repository: OWASP/www-project-juice-shop
-code_user: bkimminich
+code_user: juice-shop
 code_repo: juice-shop


### PR DESCRIPTION
Hi @bkimminich and the Team @OWASPFoundation , 

- fix: Watch and Star - GitHub buttons (update GitHub repo reference from bkimminich/juice-shop to juice-shop/juice-shop)

It is quite important to be fixed, as instead of new followers and stars (boosting repo stats), visitors see `404 error` page.

# Description
The project `_config.yml` still referenced the old repository `bkimminich/juice-shop`, which no longer exists and leads to 404 errors in the OWASP project page sidebar.

This PR updates:
- `code_user: juice-shop`
- `code_repo: juice-shop`

so that the Watch/Star links on https://owasp.org/www-project-juice-shop/ now point to the correct main repository https://github.com/juice-shop/juice-shop.

Fixed: https://github.com/OWASP/www-project-juice-shop/issues/14 

References I used (useful):
- https://owasp.org/site-documentation/
- https://github.com/OWASP/www--site-theme/blob/main/_includes/github-buttons.html

_Note for reviewer: It should fixed mentioned issue. Please let me know if something to change._

Best regards,
