### PR TITLE
ci(changed-attributions): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/changed-attributions.yml
+++ b/.github/workflows/changed-attributions.yml
@@ -6,6 +6,9 @@ on:
     paths: 
       - '_data/ow_attributions.json'
 
+permissions:
+  contents: read
+
 jobs:
   slackNotification:
     name: Slack Notification


### PR DESCRIPTION
The `changed-attributions` workflow validates attribution changes against the diff. No GitHub API writes, so workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening shape. YAML validated locally.